### PR TITLE
[수정] 상세페이지 제품 스펙 탭 추가 및 버그 수정

### DIFF
--- a/src/components/myPage/OrderHistory.tsx
+++ b/src/components/myPage/OrderHistory.tsx
@@ -7,6 +7,7 @@ import {
   where,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 // 전체 주문 내역
 interface Order {
@@ -27,6 +28,7 @@ interface OrderItem {
 
 export default function OrderHistory() {
   const [orderHistory, setOrderHistory] = useState<Order[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -35,7 +37,8 @@ export default function OrderHistory() {
       const currentUser = auth.currentUser;
 
       if (!currentUser) {
-        console.error('로그인 상태가 아닙니다');
+        window.history.replaceState(null, '', '/login');
+        navigate('/login', { replace: true });
         return;
       }
 

--- a/src/components/myPage/UserInfo.tsx
+++ b/src/components/myPage/UserInfo.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useState } from 'react';
 
 import SearchAddress from '@/components/common/SearchAddress';
+import UserInfoInput from '@/components/myPage/UserInfoInput';
 import { getUserInfo, updateUserAddress, updateUserPassword } from '@/firebase';
-import UserInfoInput from './UserInfoInput';
-
-export interface User {
-  userid: string | null;
-  username: string | null;
-  email: string | null;
-  address: string | null;
-  details: string | null;
-}
+import { UserData } from '@/types';
 
 export default function UserInfo() {
   const [user, setUser] = useState<UserData | null>(null);
@@ -138,7 +131,7 @@ export default function UserInfo() {
         <div>
           <div>주소</div>
           <div className="mt-5">
-            기존 주소 : {user?.address} {user?.details}
+            기존 주소 : {user?.address} {user?.detailAddress}
           </div>
           <div className="mt-[10px] flex flex-col gap-[5px]">
             <UserInfoInput

--- a/src/components/payment/ShippingAddress.tsx
+++ b/src/components/payment/ShippingAddress.tsx
@@ -59,7 +59,7 @@ export default function ShippingAddress({
 
   const handleSearchAddress = async () => {
     const searchedAddress = (await SearchAddress()) || '';
-    updateInputValues('address', searchedAddress);
+    updateInputValues('baseAddress', searchedAddress);
   };
 
   return (

--- a/src/components/productDetail/ProductDescription.tsx
+++ b/src/components/productDetail/ProductDescription.tsx
@@ -8,6 +8,48 @@ export default function ProductDescription({ product }: { product: any }) {
     }),
   );
 
+  const fieldMappings = [
+    { field: 'brand', name: '제조 회사', format: (value: string) => value },
+    {
+      field: 'release',
+      name: '출시 연도',
+      format: (value: string) => `${value}년`,
+    },
+    {
+      field: 'opt_color',
+      name: '제품 색상',
+      format: (value: Record<string, number>) => Object.keys(value).join('/'),
+    },
+    {
+      field: 'opt_storage',
+      name: '저장 용량',
+      format: (value: Record<string, number>) => Object.keys(value).join('/'),
+    },
+    { field: 'size', name: '화면크기', format: (value: string) => value },
+    {
+      field: 'feature',
+      name: '지원 기능',
+      format: (value: Record<string, number>) => Object.keys(value).join('/'),
+    },
+    {
+      field: 'watch',
+      name: '지원 기능',
+      format: (value: Record<string, number>) => Object.keys(value).join('/'),
+    },
+    {
+      field: 'earphone',
+      name: '지원 기능',
+      format: (value: Record<string, number>) => Object.keys(value).join('/'),
+    },
+  ];
+
+  const transformedData = fieldMappings
+    .filter(({ field }) => product[field] !== undefined)
+    .map(({ field, name, format }) => ({
+      name,
+      value: format(product[field]),
+    }));
+
   const returnExchaneInfo = [
     { name: '판매자 지정택배사', value: 'CJ대한통운' },
     { name: '반품배송비', value: '편도 3,000원' },
@@ -42,6 +84,7 @@ export default function ProductDescription({ product }: { product: any }) {
       <TabGroup className="mb-8 min-h-[800px]">
         <TabList className="mb-9 flex h-11 w-full gap-24 border-b text-2xl font-extrabold text-gray md:justify-center md:gap-10">
           <Tab className="data-[selected]:text-black">제품 설명</Tab>
+          <Tab className="data-[selected]:text-black">제품 스펙</Tab>
           <Tab className="data-[selected]:text-black">반품/교환 정보</Tab>
         </TabList>
         <TabPanels id="productDescription">
@@ -55,6 +98,28 @@ export default function ProductDescription({ product }: { product: any }) {
               />
             ))}
           </TabPanel>
+          <TabPanel id="productSpecs">
+            <div className="my-10 flex flex-col gap-5">
+              <div className="text-center text-3xl">제품 상세 스펙</div>
+            </div>
+            <table className="flex w-full justify-center px-10 text-xl">
+              <tbody className="grid w-full grid-cols-1">
+                {transformedData.map((detail, index) => (
+                  <tr
+                    key={index}
+                    className="flex h-12 w-full border border-gray"
+                  >
+                    <th className="flex w-1/3 items-center bg-[#D9D9D9] pl-2">
+                      {detail.name}
+                    </th>
+                    <td className="flex w-2/3 items-center pl-2">
+                      {detail.value}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TabPanel>
           <TabPanel id="returnExchange" className="w-full">
             <div className="my-10 flex flex-col gap-5">
               <div className="text-center text-3xl">
@@ -65,7 +130,7 @@ export default function ProductDescription({ product }: { product: any }) {
                 반품지 주소 등을 협의하신 후 반품상품을 발송해주시기 바랍니다.
               </div>
             </div>
-            <tbody className="flex w-full flex-col px-10 text-left">
+            <tbody className="flex w-full flex-col px-10 text-left text-xl">
               {returnExchaneInfo.map((info, index) => (
                 <tr key={index} className="flex w-full border border-gray">
                   <th className="flex w-3/12 items-center bg-[#D9D9D9] py-4 pl-2">

--- a/src/components/productDetail/ProductDescription.tsx
+++ b/src/components/productDetail/ProductDescription.tsx
@@ -130,22 +130,26 @@ export default function ProductDescription({ product }: { product: any }) {
                 반품지 주소 등을 협의하신 후 반품상품을 발송해주시기 바랍니다.
               </div>
             </div>
-            <tbody className="flex w-full flex-col px-10 text-left text-xl">
-              {returnExchaneInfo.map((info, index) => (
-                <tr key={index} className="flex w-full border border-gray">
-                  <th className="flex w-3/12 items-center bg-[#D9D9D9] py-4 pl-2">
-                    {info.name}
-                  </th>
-                  <td className="flex w-9/12 items-center py-4 pl-2">
-                    <div className="flex flex-col">
-                      {Array.isArray(info.value)
-                        ? info.value.map((value, i) => <li key={i}>{value}</li>)
-                        : info.value}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
+            <table>
+              <tbody className="flex w-full flex-col px-10 text-left text-xl">
+                {returnExchaneInfo.map((info, index) => (
+                  <tr key={index} className="flex w-full border border-gray">
+                    <th className="flex w-3/12 items-center bg-[#D9D9D9] py-4 pl-2">
+                      {info.name}
+                    </th>
+                    <td className="flex w-9/12 items-center py-4 pl-2">
+                      <div className="flex flex-col">
+                        {Array.isArray(info.value)
+                          ? info.value.map((value, i) => (
+                              <li key={i}>{value}</li>
+                            ))
+                          : info.value}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </TabPanel>
         </TabPanels>
       </TabGroup>

--- a/src/components/productDetail/ProductOptions.tsx
+++ b/src/components/productDetail/ProductOptions.tsx
@@ -188,6 +188,25 @@ export default function ProductOptions({
     }
   };
 
+  const unitPriority: { [key: string]: number } = { MB: 0, GB: 1, TB: 2 };
+
+  const sortBySize = (options: string[]): string[] => {
+    return options.sort((a, b) => {
+      // 용량 정보를 분리하고, 없으면 null 반환
+      const aMatch = a.match(/(\d+)(MB|GB|TB)/);
+      const bMatch = b.match(/(\d+)(MB|GB|TB)/);
+
+      // 용량 단위가 있으면 우선순위로 정렬하고, 없으면 그냥 정렬하지 않음
+      const aSize = aMatch
+        ? unitPriority[aMatch[2] as keyof typeof unitPriority]
+        : Infinity;
+      const bSize = bMatch
+        ? unitPriority[bMatch[2] as keyof typeof unitPriority]
+        : Infinity;
+      return aSize - bSize;
+    });
+  };
+
   return (
     <div className="w-full">
       <div className="flex flex-col gap-6 md:items-center md:gap-4">
@@ -218,7 +237,7 @@ export default function ProductOptions({
             <SelectOption
               key={index}
               name={key}
-              options={Object.keys(value).sort()}
+              options={sortBySize(Object.keys(value))}
               value={selectedOptions[key]}
               onChange={handleSelectedOptions}
             />

--- a/src/components/productSearch/Product/ProductListPage.tsx
+++ b/src/components/productSearch/Product/ProductListPage.tsx
@@ -103,7 +103,7 @@ const ProductListPage: React.FC<ProductListPageProps> = ({
             />
           ))
         ) : (
-          <p>로딩 중...</p>
+          <p>검색 결과가 없습니다.</p>
         )}
       </ProductContainer>
     </div>

--- a/src/pages/RecommendPage.tsx
+++ b/src/pages/RecommendPage.tsx
@@ -1,11 +1,11 @@
 function RecommendPage() {
   return (
     <>
-      <div className="mt-44 flex h-screen flex-col items-center gap-4 text-2xl">
+      <div className="mx-10 mt-44 flex h-screen flex-col items-center gap-4 text-2xl">
         <div>서비스가 준비중에 있습니다.</div>
         <div>
-          더 나은 서비스를 제공하기 위해 최선을 다하고 있습니다. 이용에 불편을
-          드려 죄송하며, 빠른 시일 내에 찾아뵙겠습니다. 감사합니다.
+          이용에 불편을 드려 죄송하며, 빠른 시일 내에 찾아뵙겠습니다.
+          감사합니다.
         </div>
       </div>
     </>


### PR DESCRIPTION
추가
- 상세 페이지: 제품 스펙 데이터 구조 확정이 늦어져 후순위로 미뤄둔 제품 상세스펙 탭을 추가
(레이아웃 작업 후 기능 구현 단계에서 삭제했었던 탭 복구)

버그 수정
- 데이터 타입 오류, DOM 구조 경고 등 수정
- 결제 페이지: 도로명주소 검색결과 반영 안됨 수정
- 마이 페이지: 비로그인 상태에서는 로그인 페이지로 연결 (뒤로가기 동작을 위해 히스토리 조작)
- 상세 페이지: 구매 옵션 선택지(용량)에 용량별 정렬 적용